### PR TITLE
fix: pdf introduction about function pack and function pack(l) itself…

### DIFF
--- a/exercises/introduction/assignment.tex
+++ b/exercises/introduction/assignment.tex
@@ -316,7 +316,7 @@ result of evaluating the function.
 \item {\tt unique(l)}: return a list of unique elements in the list {\em l},
   that is {\tt [:a, :b, :d]} are the unique elements in the list {\tt [:a, :b, :a, :d, :a, :b, :b, :a]}
 \item {\tt pack(l)}: return a list containing lists of equal elements, {\tt
-  [:a, :a, :b, :c, :b, :a, :c]} should return {\tt [[:a, :a, :a], [b], [:c, :c]]}
+  [:a, :a, :b, :c, :b, :a, :c]} should return {\tt [[:a, :a, :a], [:b, :b], [:c, :c]]}
 \item {\tt reverse(l)}: return a list where the order of elements is reversed
 \end{itemize}
 

--- a/exercises/introduction/src/list_operations.ex
+++ b/exercises/introduction/src/list_operations.ex
@@ -1,5 +1,5 @@
 defmodule ListOperations do
-  
+
   # Returns the n´th elemt of the list.
   def nth(0, [head | _tail]) do head end
   def nth(n, [_head | tail]) do nth(n - 1, tail) end
@@ -14,7 +14,7 @@ defmodule ListOperations do
 
   # Returns a list where all the elements are duplicated.
   def duplicate([]) do [] end
-  def duplicate([head | tail]) do 
+  def duplicate([head | tail]) do
     [head, head | duplicate(tail)]
   end
 
@@ -40,7 +40,7 @@ defmodule ListOperations do
   # Returns a list containing lists of equal elements.
   def pack([]) do [] end
   def pack([x | tail]) do
-    {all, rest} = match(x, tail, [], [])
+    {all, rest} = match(x, tail, [x], [])
     [all | pack(rest)]
   end
 


### PR DESCRIPTION
… on list_operations.ex corrected. actual was [[:a, :a], [:c], [:b]] instead of [[:a, :a, :a], [:c, :c], [:b, :b]]