### PR TITLE
Fixes

### DIFF
--- a/erlang/seminars/lambda/assignment.tex
+++ b/erlang/seminars/lambda/assignment.tex
@@ -53,7 +53,7 @@ In the dawn of computers the only programming language was the language of
 the hardware i.e. assembler. In the late fifties computers were
 however powerful enough to allow programs, written in high-level
 languages, to be compiled to machine code. One of the first high-level
-languages that were defined was Lisp. It was developed by John
+languages that was defined was Lisp. It was developed by John
 McCarthy in 1958 and was directly based on \lamc. It introduced many
 features of programming languages that we now take for granted.
 
@@ -141,7 +141,7 @@ A \betar\ is what we do when we apply a \lama\ to an argument. We will
 write substitution using the following notation $$(2x + 5)[x/3]$$ We
 can write down some formal rules for what it means to do substitution
 but it is all quite simple. The only thing we have to be careful
-about is when we want to substitute one variable by another. This
+about is when we want to substitute one variable for another. This
 could of course lead to very strange situations. 
 
 If we have the abstraction
@@ -309,12 +309,12 @@ $$\lambda x \rightarrow (\lambda y \rightarrow x + y )$$
 Applying one argument after the other is rather complicated and
 therefor any functional programming language have a syntax that allows more arguments. The
 important thing to note is, that we do not have to change or add any
-rules to the calulus. It is all just syntactic sugar that is it makes
+rules to the calulus. It is all just syntactic sugar that makes
 things easier to read and write.
 
-While using several arguments to a function make life easier the
+While using several arguments to a function makes life easier,
 we sometimes want to do the opposite. We want to
-turn a function of several parameters to a sequence of functions of
+turn a function of several parameters into a sequence of functions of
 one parameter each. This is so important that it has been given a
 name, {\em currying}, after the mathematician Haskell B. Curry (who also
 gave name to the language Haskell).
@@ -352,7 +352,7 @@ following function in Erlang.
 \end{center}
 \vspace{10pt}
 
-How is this translated into \lamc? There is nothing called a sequence
+How is this translated into \lamc? There is no such thing as a sequence
 in \lamc\ so we have to rewrite it in terms of regular language
 constructs. We rewrite the abstraction as follows:
 
@@ -402,7 +402,7 @@ so common to use infinite structures that it is provided by default.
 
 Haskell is as we mentioned a language that uses lazy-evaluation so it
 is more natural to work with infinite structures. Working with
-infinite structures is quite fun and you can write very nice program
+infinite structures is quite fun and you can write very nice programs
 (that are mind-boggling) but in Erlang it is not allowed (or rather we
 have to construct them manually).
 
@@ -687,7 +687,7 @@ try the following:
  :
 \end{verbatim}
 
-I you think this was complicated you're right! Church never figured
+If you think this was complicated you're right! Church never figured
 out how to express the predecessor function. It one of his students,
 Stephen Kleene, that four years later showed his professor that the
 \lamc\ could express something as simple as the predecessor function. 
@@ -793,7 +793,7 @@ otherwise get.
 \section{Summary}
 
 If you have implemented the Church numerals I think that you have a
-better understanding of what the \lamc\ is. I also hope that you're a
+better understanding of what \lamc\ is. I also hope that you're a
 little bit better in working with functions as arguments and return
 values. This is something that you will not use very much in the
 beginning but once you get use to it you will realize how powerful it

--- a/erlang/seminars/operational/assignment.tex
+++ b/erlang/seminars/operational/assignment.tex
@@ -30,26 +30,26 @@ any room for interpretation since the description is what defines the
 language.
 
 The operational semantics should preferably be described in a way that
-it also captures the time and memory complexity of an execution. It
+also capture the time and memory complexity of an execution. It
 does not have to be a detailed description of how things are actually
 implemented but it should give an understanding of the execution to
 allow a programmer to reason about the efficiency of a particular
 program.
 
-The operational semantics of a language can also serve as a
+The operational semantics of a language can also serve as an
 architecture for an abstract machine for the language or as the design
 criteria for a compiler. The observable properties of a program
 execution should conform to the properties one can derive from the
 description of the operational semantics.
 
-There are many ways to describe an operational semantics of a
+There are many ways to describe operational semantics of a
 programming language and we will use a strategy called {\em big-step
   semantics}. We will describe the semantics as a set of rewrite rules
-or evaluation relation; given an expression in the language we ill
+or evaluation relation; given an expression in the language we will
 describe the rule of how to evaluate the expression to obtain an
 answer.
 
-This description of an operational semantics for our small functional
+This description of operational semantics for our small functional
 programming language will serve our purposes in that we will be able
 to talk and reason about program execution. We will also be able to
 use it when we implement an interpreter for the langauge.
@@ -59,7 +59,7 @@ use it when we implement an interpreter for the langauge.
 
 Our language is a very small functional programming language. We will
 in the beginning only have a handful of data types and program
-constructions but will the extend the language to look more like a
+constructions but will then extend the language to look more like a
 proper language. To start with our language will only consist of the
 constructs to express a sequence of pattern matching expressions
 followed by a single expression.
@@ -133,7 +133,7 @@ There is of course a equivalence relation between our atoms in the
 language and the atoms in the domain. You might wonder if they are not
 the same but there is a difference between expressions in our language
 and elements in our domain. Think about the written number ``12'' or
-in Roman ``XII'' and the number twelve. We will have expression that
+in Roman ``XII'' and the number twelve. We will have expressions that
 look like {\tt \{foo, \{bar, zot\}\}} and data structures that we
 write {\em c(foo, c(bar, zot))}. If everything works out fine, the
 {\em evaluation} of an expression will return the corresponding data
@@ -149,7 +149,7 @@ matching expressions.
 
 An environment is represented as a set of bindings $v/s$. Here $v$ is
 a variable (and we will typically use $v$ or $x$, $y$ etc when we talk
-about variables) and $t$ is a data structure. An environment that
+about variables) and $s$ is a data structure. An environment that
 binds X to a and Y to b would then be written:
 
 $$\{X/a, Y/b\}$$
@@ -462,7 +462,7 @@ $$\frac{E\sigma(e) \rightarrow v_1, \ldots:{\rm seq}:\theta \qquad E\sigma(e_i) 
 E\sigma(e(e_1, \ldots)) \rightarrow s}$$ 
 
 Note that the closure that we get, $v_1, \ldots:{\rm seq}:\theta$
-consist of a sequence of variables $v_1, \ldots$, that are all
+consists of a sequence of variables $v_1, \ldots$, that are all
 distinct. This is why we can simply add the bindings
 $v_i/s_i$ to $\theta$, there will not be any duplicate bindings.
 


### PR DESCRIPTION
• Just basic grammar and typos
• One typo below that couldn't be fixed; remove the extra 'e'
```
def pred(n) do
fn(f, x) ->
( n.( # n is a Church numeral
fn(g) -> fn(h) -> h.(g.(f)) end end, # apply this function n times
fn(_) -> x end) # to this function
).(fn(u) -> u end) # apply it to thee identity function
end
end
```
