### PR TITLE
suggestion for exercise instructions fix

### DIFF
--- a/exercises/twothree/assignment.tex
+++ b/exercises/twothree/assignment.tex
@@ -61,11 +61,11 @@ not to much overhead.
 
 All operations (search, insert, delete) are $O(lg(n))$ and there are
 no worst case scenarios since the insert and delete operations will
-preserve the balance. We're not relying on luck as we are if we us a
+preserve the balance. We're not relying on luck as we are if we use a
 simple binary tree.
 
 In this assignment you're going to learn how to implement a quite
-tricky algorithm and doing so using pattern matching. If you don't
+tricky algorithm and you will do so using pattern matching. If you don't
 remember how 2-3 trees work refresh your memory before you start.
 
 
@@ -76,11 +76,11 @@ remember how 2-3 trees work refresh your memory before you start.
 \section{The 2-3 tree}
 
 In this implementation we will create a 2-3 tree that keeps key-value
-pairs. The key-values will only reside in the leafs of the tree but he
+pairs. The key-values will only reside in the leaves of the tree but the
 keys will of course also be present in the nodes to guide a search.
 
 A tree is either: empty, a leaf, a two-node or a {\em three-node}. The
-tree is balanced so all leafs are on the same level in the tree. A
+tree is balanced so all leaves are on the same level in the tree. A
 simple representation of these different trees could be:
 
 \begin{itemize}
@@ -92,7 +92,7 @@ simple representation of these different trees could be:
 
 All keys in the left branch of a two-node are smaller or equal to the
 key of the node. In a three-node the keys of the left branch is
-smaller of equal to the first key and the keys of the middle branch are
+smaller or equal to the first key and the keys of the middle branch are
 less than or equal to the second key.
 
 We will in our implementation also work with a third type of node, a
@@ -120,51 +120,51 @@ with a four-node. Let's start with a description of the simple cases:
 
 \begin{itemize}
     \item {\em empty tree}: To insert a key-value pair in an empty tree return a leaf containing the key and value.
-    \item {\em a lead}: To insert a key-value pair in a leaf return a
+    \item {\em a leaf}: To insert a key-value pair in a leaf, return a
     two-node containing the existing leaf and a new leaf. The smaller
     of the keys should be the key of the two-node.
 \end{itemize}
 
 So far, so good - now to the case were we have a two-node or a
-three-node. We should do quite different thing depending on if the
-node holds leafs or if it is an internal node that holds two-nodes or
+three-node. We should do quite different things depending on if the
+node holds leaves or if it is an internal node that holds two-nodes or
 three-nodes. Note that a two-node or three-node either holds only
-leafs or only two- and three-nodes, it can not hold only one leaf node
-since all leafs are on the same level in the tree.
+leaves or only two- and three-nodes, it can not hold only one leaf node
+since all leaves are on the same level in the tree.
 
 So let's see what the rules are if we encounter a two- or three-node
-that holds only leafs.
+that holds only leaves.
 
 \begin{itemize}
-    \item {\em two-node holding leafs}: Create a new leaf and return a
-    three-node containing all three leafs. Make sure that the leafs
-    are ordered and that the three-node hold the two smallest keys.
-    \item {\em three-node holding leafs}: Cr-eat a new leaf and return a
-    four-node containing all four leafs. Make sure that the leafs
-    are ordered and that the four-node hold the three smallest keys.     
+    \item {\em two-node holding leaves}: Create a new leaf and return a
+    three-node containing all three leaves. Make sure that the leaves
+    are ordered and that the three-node holds the two smallest keys.
+    \item {\em three-node holding leaves}: Create a new leaf and return a
+    four-node containing all four leaves. Make sure that the leaves
+    are ordered and that the four-node holds the three smallest keys.     
 \end{itemize}
 
-Now this was simple but we have of course possibly returned a
+Now, this was simple but we have of course possibly returned a
 four-node. We will see how this will be removed when we do the
 recursive step.
 
-When we encounter an internal two-node or three-node will proceed and
-insert the new key-value pair in the right branch. If we do this we
+When we encounter an internal two-node or three-node we will proceed and
+insert the new key-value pair in the appropriate branch. If we do this we
 could end up with a four-node and then we have to think twice before
 we return an new tree.
 
 \begin{itemize}
-    \item {\em two-node general case}: If the insert operation of the right branch returns a four-node, construct a valid three-node, where the middle key of the returned four-node is the new key in the three-node. Otherwise, return an updated two-node.
-    \item {\em three-node general case}: If the insert operation of the right branch returns a four-node, construct a valid four-node, where the middle key of the returned four-node is the new key in the four-node. Otherwise, return an updated three-node.
+    \item {\em two-node general case}: If the insert operation on a branch returns a four-node, construct a valid three-node, where the middle key of the returned four-node is the new key in the three-node. Otherwise, return an updated two-node.
+    \item {\em three-node general case}: If the insert operation on a branch returns a four-node, construct a valid four-node, where the middle key of the returned four-node is the new key in the four-node. Otherwise, return an updated three-node.
 \end{itemize}
 
 The only thing that is left is the rule to handle the root of the
 tree. Everything works fine with the rules that we have but it could
-of course be that we will return a four-node and we don't want to have
+of course be that we will return a four-node, and we don't want to have
 four-nodes in our tree.
 
 \begin{itemize}
-    \item {\em the root} : If, by updating the root, we return a four-node
+    \item {\em the root}: If, by updating the root, we return a four-node,
     then split the four-node into two two-nodes that are branches of a
     new two-node root.
 \end{itemize}
@@ -181,7 +181,7 @@ That is it, now let's see how hard this is to implement.
 Let's implement a function {\tt insertf(key, value, tree)} that takes a
 key, a value and a 2-3 tree and returns a 2-3 tree or possibly a
 four-node containing 2-3 trees of equal depth (we will deal with the
-root case last). Look at the rules and star with the base cases.
+root case last). Look at the rules and start with the base cases.
 
 \begin{minted}{elixir}
 def insertf(key, value, nil), do: {:leaf, key, value}
@@ -196,17 +196,17 @@ def insertf(k, v, {:leaf, k1, _} = l) do
 end
 \end{minted}
 
-You might not have seen the construct {\tt =l} in the head but it is a
+You might not have seen the construct {\tt = l} in the head but it is a
 very convenient syntax. We do want the second argument to match the
 pattern but at the same time we would like to use the data
 structure. We could have written this without using this syntax but it
 would be more to write and it would not be as efficient.
 
 So the two first rules was easy, now for the rules were we are looking
-at a two-node that holds only leafs. I leave this with some holes for
-you to fill in, you should do more than just copy and paste. Look at
+at a two-node that holds only leaves. I leave this with some holes for
+you to fill in; you should do more than just copy and paste. Look at
 the rules, you should return a three-node that holds two keys and
-three leafs.
+three leaves.
 
 \begin{minted}{elixir}
 def insertf(k, v, {:two, k1, {:leaf, k1, _} = l1, 
@@ -223,11 +223,11 @@ end
 \end{minted}
 
 The keys should of course be {\tt k1}, {\tt k2} and {\tt k}, but in
-the right order and the corresponding leafs should follow. When you
+the right order and the corresponding leaves should follow. When you
 think you have it, take it for a spin, terminate the clause with a dot,
-compile and do some experiments. You should be able to handle a empty
-tree, a tree of only a leaf and a two-node with two leafs. If you got
-it proceed to the three-node.
+compile and do some experiments. You should be able to handle an empty
+tree, a tree of only a leaf and a two-node with two leaves. If you got
+it, proceed to the three-node.
 
 \begin{minted}{elixir}
 def insertf(k, v, {:three, k1, k2, {:leaf, k1, _} = l1,
@@ -248,7 +248,7 @@ end
 
 
 What is the result of inserting a key-value pair in a three-node
-holding three leafs? Look at the rule, complete the code, compile and
+holding three leaves? Look at the rule, complete the code, compile and
 test. Ok - then the recursive cases.
 
 \begin{minted}{elixir}
@@ -325,5 +325,25 @@ def insertf(k, v, {:three, k1, k2, left, middle, right}) do
   end
 end
 \end{minted}
+
+Last but not least, we must handle the root case. Take another look at the
+final part of the rules for insertion. When updating the root results in a
+four-node, we must split it up into two-nodes, increasing the height of the
+tree by one in the process. We define a new function for this, that will
+also act as the interface to this module.
+
+\begin{minted}{elixir}
+def insert(key, value, root) do
+  case insertf(key, value, root) do
+    {:four, q1, q2, q3, t1, t2, t3, t4} ->
+      ...
+    updated ->
+      ...
+  end
+end
+\end{minted}
+
+You should now be able to create a 2-3 tree of arbitrary size by repeatedly
+calling the new function.
 
 \end{document}


### PR DESCRIPTION
Changes to the instructions of the 2-3 Tree exercise:

- Added instructions for handling the splitting of the root node so that students get a complete implementation out of the exercise (at least as far as insertion goes). Made sure it matches the teachers solution in two_three_tree.ex, and that the writing matches the style of the rest of the document.

- Fixed numerous typos and changed a few unclear formulations.